### PR TITLE
Pull the changes on the develop branch to master

### DIFF
--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -32,7 +32,7 @@ class CalendarHTMLFormatter implements CalendarFormatterInterface
                 'sm' => new SmallTimestampsHTMLFormatter(),
                 'xs' => new ExtraSmallTimestampsHTMLFormatter(),
             ],
-            \CultureFeed_Cdb_Data_Calendar_Period::class =>
+            \CultureFeed_Cdb_Data_Calendar_PeriodList::class =>
             [
                 'lg' => new LargePeriodHTMLFormatter(),
                 'md' => new MediumPeriodHTMLFormatter(),

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -12,7 +12,7 @@ use CultuurNet\CalendarSummary\Period\ExtraSmallPeriodHTMLFormatter;
 use CultuurNet\CalendarSummary\Period\LargePeriodHTMLFormatter;
 use CultuurNet\CalendarSummary\Period\MediumPeriodHTMLFormatter;
 use CultuurNet\CalendarSummary\Period\SmallPeriodHTMLFormatter;
-use CultuurNet\CalendarSummary\Permanent\LargePermanentFormatter;
+use CultuurNet\CalendarSummary\Permanent\LargePermanentHTMLFormatter;
 use CultuurNet\CalendarSummary\Timestamps\ExtraSmallTimestampsHTMLFormatter;
 use CultuurNet\CalendarSummary\Timestamps\LargeTimestampsHTMLFormatter;
 use CultuurNet\CalendarSummary\Timestamps\MediumTimestampsHTMLFormatter;
@@ -41,7 +41,7 @@ class CalendarHTMLFormatter implements CalendarFormatterInterface
             ],
             \CultureFeed_Cdb_Data_Calendar_Permanent::class =>
             [
-                'lg' => new LargePermanentFormatter(),
+                'lg' => new LargePermanentHTMLFormatter(),
             ],
         ];
     }

--- a/src/CalendarHTMLFormatter.php
+++ b/src/CalendarHTMLFormatter.php
@@ -48,12 +48,14 @@ class CalendarHTMLFormatter implements CalendarFormatterInterface
 
     public function format(\CultureFeed_Cdb_Data_Calendar $calendar, $format)
     {
-        // TODO: Implement format() method.
-        // Check which kind of Calendar we get in (Calendar is abstract class).
-        // Then use the mapping to do the correct formatting.
-
         $class = get_class($calendar);
-        $formatter = $this->mapping[$class][$format];
+
+        if (isset($this->mapping[$class][$format])) {
+            $formatter = $this->mapping[$class][$format];
+        } else {
+            throw new FormatterException($format . ' format not supported for ' . $class);
+        }
+
         return $formatter->format($calendar);
     }
 }

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -48,12 +48,14 @@ class CalendarPlainTextFormatter implements CalendarFormatterInterface
 
     public function format(\CultureFeed_Cdb_Data_Calendar $calendar, $format)
     {
-        // TODO: Implement format() method.
-        // Check which kind of Calendar we get in (Calendar is abstract class).
-        // Then use the mapping to do the correct formatting.
-
         $class = get_class($calendar);
-        $formatter = $this->mapping[$class][$format];
+
+        if (isset($this->mapping[$class][$format])) {
+            $formatter = $this->mapping[$class][$format];
+        } else {
+            throw new FormatterException($format . ' format not supported for ' . $class);
+        }
+
         return $formatter->format($calendar);
     }
 }

--- a/src/CalendarPlainTextFormatter.php
+++ b/src/CalendarPlainTextFormatter.php
@@ -32,7 +32,7 @@ class CalendarPlainTextFormatter implements CalendarFormatterInterface
                 'sm' => new SmallTimestampsPlainTextFormatter(),
                 'xs' => new ExtraSmallTimestampsPlainTextFormatter(),
             ],
-            \CultureFeed_Cdb_Data_Calendar_Period::class =>
+            \CultureFeed_Cdb_Data_Calendar_PeriodList::class =>
             [
                 'lg' => new LargePeriodPlainTextFormatter(),
                 'md' => new MediumPeriodPlainTextFormatter(),

--- a/src/Period/ExtraSmallPeriodHTMLFormatter.php
+++ b/src/Period/ExtraSmallPeriodHTMLFormatter.php
@@ -12,8 +12,9 @@ class ExtraSmallPeriodHTMLFormatter implements PeriodFormatterInterface
 {
 
     public function format(
-        \CultureFeed_Cdb_Data_Calendar_Period $period
+        \CultureFeed_Cdb_Data_Calendar_PeriodList $periodList
     ) {
+        $period = $periodList->current();
         $dateFrom = $period->getDateFrom();
 
         $dateFromDay = date('j', strtotime($dateFrom));

--- a/src/Period/ExtraSmallPeriodPlainTextFormatter.php
+++ b/src/Period/ExtraSmallPeriodPlainTextFormatter.php
@@ -11,8 +11,9 @@ namespace CultuurNet\CalendarSummary\Period;
 class ExtraSmallPeriodPlainTextFormatter implements PeriodFormatterInterface
 {
     public function format(
-        \CultureFeed_Cdb_Data_Calendar_Period $period
+        \CultureFeed_Cdb_Data_Calendar_PeriodList $periodList
     ) {
+        $period = $periodList->current();
         $dateFrom = $period->getDateFrom();
 
         $dateFromDay = date('j', strtotime($dateFrom));

--- a/src/Period/LargePeriodHTMLFormatter.php
+++ b/src/Period/LargePeriodHTMLFormatter.php
@@ -38,8 +38,9 @@ class LargePeriodHTMLFormatter implements PeriodFormatterInterface
     );
 
     public function format(
-        \CultureFeed_Cdb_Data_Calendar_Period $period
+        \CultureFeed_Cdb_Data_Calendar_PeriodList $periodList
     ) {
+        $period = $periodList->current();
         $output = $this->generateDates($period->getDateFrom(), $period->getDateTo());
         $output .= $this->generateWeekscheme($period->getWeekScheme());
 

--- a/src/Period/LargePeriodPlainTextFormatter.php
+++ b/src/Period/LargePeriodPlainTextFormatter.php
@@ -29,8 +29,9 @@ class LargePeriodPlainTextFormatter implements PeriodFormatterInterface
 
 
     public function format(
-        \CultureFeed_Cdb_Data_Calendar_Period $period
+        \CultureFeed_Cdb_Data_Calendar_PeriodList $periodList
     ) {
+        $period = $periodList->current();
         $output = $this->generateDates($period->getDateFrom(), $period->getDateTo());
         $output .= $this->generateWeekscheme($period->getWeekScheme());
 

--- a/src/Period/MediumPeriodHTMLFormatter.php
+++ b/src/Period/MediumPeriodHTMLFormatter.php
@@ -14,7 +14,7 @@ class MediumPeriodHTMLFormatter implements PeriodFormatterInterface
 {
 
     public function format(
-        \CultureFeed_Cdb_Data_Calendar_Period $period
+        \CultureFeed_Cdb_Data_Calendar_PeriodList $periodList
     ) {
         $fmt = new IntlDateFormatter(
             'nl_BE',
@@ -24,6 +24,8 @@ class MediumPeriodHTMLFormatter implements PeriodFormatterInterface
             IntlDateFormatter::GREGORIAN,
             'd MMMM Y'
         );
+
+        $period = $periodList->current();
         $dateFromString = $period->getDateFrom();
         $dateFrom = strtotime($dateFromString);
         $intlDateFrom =$fmt->format($dateFrom);

--- a/src/Period/MediumPeriodPlainTextFormatter.php
+++ b/src/Period/MediumPeriodPlainTextFormatter.php
@@ -14,7 +14,7 @@ class MediumPeriodPlainTextFormatter implements PeriodFormatterInterface
 {
 
     public function format(
-        \CultureFeed_Cdb_Data_Calendar_Period $period
+        \CultureFeed_Cdb_Data_Calendar_PeriodList $periodList
     ) {
         $fmt = new IntlDateFormatter(
             'nl_BE',
@@ -24,6 +24,8 @@ class MediumPeriodPlainTextFormatter implements PeriodFormatterInterface
             IntlDateFormatter::GREGORIAN,
             'd MMMM Y'
         );
+
+        $period = $periodList->current();
         $dateFromString = $period->getDateFrom();
         $dateFrom = strtotime($dateFromString);
         $intlDateFrom =$fmt->format($dateFrom);

--- a/src/Period/PeriodFormatterInterface.php
+++ b/src/Period/PeriodFormatterInterface.php
@@ -12,8 +12,8 @@ interface PeriodFormatterInterface
 {
 
     /**
-     * @param \CultureFeed_Cdb_Data_Calendar_Period $period
+     * @param \CultureFeed_Cdb_Data_Calendar_PeriodList $period
      * @return string
      */
-    public function format(\CultureFeed_Cdb_Data_Calendar_Period $period);
+    public function format(\CultureFeed_Cdb_Data_Calendar_PeriodList $period);
 }

--- a/src/Period/SmallPeriodHTMLFormatter.php
+++ b/src/Period/SmallPeriodHTMLFormatter.php
@@ -40,8 +40,10 @@ class SmallPeriodHTMLFormatter implements PeriodFormatterInterface
         );
     }
 
-    public function format(CultureFeed_Cdb_Data_Calendar_Period $period)
-    {
+    public function format(
+        \CultureFeed_Cdb_Data_Calendar_PeriodList $periodList
+    ) {
+        $period = $periodList->current();
         $startDate = $this->dateFromString($period->getDateFrom());
         $startDate->setTime(0, 0, 1);
 

--- a/src/Period/SmallPeriodPlainTextFormatter.php
+++ b/src/Period/SmallPeriodPlainTextFormatter.php
@@ -40,8 +40,10 @@ class SmallPeriodPlainTextFormatter implements PeriodFormatterInterface
         );
     }
 
-    public function format(CultureFeed_Cdb_Data_Calendar_Period $period)
-    {
+    public function format(
+        \CultureFeed_Cdb_Data_Calendar_PeriodList $periodList
+    ) {
+        $period = $periodList->current();
         $startDate = $this->dateFromString($period->getDateFrom());
         $startDate->setTime(0, 0, 1);
 

--- a/src/Timestamps/SmallTimestampsHTMLFormatter.php
+++ b/src/Timestamps/SmallTimestampsHTMLFormatter.php
@@ -57,7 +57,7 @@ class SmallTimestampsHTMLFormatter implements TimestampsFormatterInterface
 
             return $output;
         } else {
-            throw new FormatterException('xs format not supported for multiple timestamps.');
+            throw new FormatterException('sm format not supported for multiple timestamps.');
         }
     }
 }

--- a/src/Timestamps/SmallTimestampsPlainTextFormatter.php
+++ b/src/Timestamps/SmallTimestampsPlainTextFormatter.php
@@ -56,7 +56,7 @@ class SmallTimestampsPlainTextFormatter implements TimestampsFormatterInterface
 
             return $output;
         } else {
-            throw new FormatterException('xs format not supported for multiple timestamps.');
+            throw new FormatterException('sm format not supported for multiple timestamps.');
         }
     }
 }

--- a/tests/CalendarHTMLFormatterTest.php
+++ b/tests/CalendarHTMLFormatterTest.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: nicolas
+ * Date: 03/04/15
+ * Time: 14:08
+ */
+namespace CultuurNet\CalendarSummary;
+
+use CultureFeed_Cdb_Data_Calendar_Permanent;
+use CultureFeed_Cdb_Data_Calendar_Timestamp;
+use CultureFeed_Cdb_Data_Calendar_TimestampList;
+use \CultureFeed_Cdb_Data_Calendar_SchemeDay as SchemeDay;
+
+class CalendarHTMLFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CalendarHTMLFormatter
+     */
+    protected $formatter;
+
+
+    public function setUp()
+    {
+        $this->formatter = new CalendarHTMLFormatter();
+    }
+
+    public function testFormatsMultipleTimestampsWithUnexistingSmallFormat()
+    {
+        $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
+        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp1);
+        $timestamp_list->add($timestamp2);
+        $timestamp_list->add($timestamp3);
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            'sm format not supported for multiple timestamps.'
+        );
+        $this->formatter->format($timestamp_list, 'sm');
+    }
+
+    public function testFormatsMultipleTimestampsWithUnexistingExtraSmallFormat()
+    {
+        $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
+        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp1);
+        $timestamp_list->add($timestamp2);
+        $timestamp_list->add($timestamp3);
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            'xs format not supported for multiple timestamps.'
+        );
+        $this->formatter->format($timestamp_list, 'xs');
+    }
+
+    public function testFormatsMultipleTimestampsWithUnexistingCustomFormat()
+    {
+        $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
+        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp1);
+        $timestamp_list->add($timestamp2);
+        $timestamp_list->add($timestamp3);
+
+        $format = 'cnet';
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_TimestampList'
+        );
+        $this->formatter->format($timestamp_list, $format);
+    }
+
+    public function testFormatsATimestampWithSmallFormat()
+    {
+        $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
+        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp1);
+        $timestamp_list->add($timestamp2);
+        $timestamp_list->add($timestamp3);
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            'sm format not supported for multiple timestamps.'
+        );
+        $this->formatter->format($timestamp_list, 'sm');
+    }
+
+    public function testFormatsPermanentWithUnexistingSmallFormat()
+    {
+        $permanent = new CultureFeed_Cdb_Data_Calendar_Permanent();
+
+        $weekscheme = new \CultureFeed_Cdb_Data_Calendar_Weekscheme();
+
+        $monday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::MONDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot1 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $monday->addOpeningTime($ot1);
+
+        $tuesday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::TUESDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot2 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $tuesday->addOpeningTime($ot2);
+
+        $wednesday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::WEDNESDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot3 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $wednesday->addOpeningTime($ot3);
+
+        $thursday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::THURSDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot4 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $thursday->addOpeningTime($ot4);
+
+        $friday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::FRIDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot5 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $friday->addOpeningTime($ot5);
+
+        $saturday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::SATURDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot6 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '19:00:00');
+        $saturday->addOpeningTime($ot6);
+
+        $sunday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::SUNDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot7 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '19:00:00');
+        $sunday->addOpeningTime($ot6);
+
+        $weekscheme->setDay(SchemeDay::MONDAY, $monday);
+        $weekscheme->setDay(SchemeDay::TUESDAY, $tuesday);
+        $weekscheme->setDay(SchemeDay::WEDNESDAY, $wednesday);
+        //$weekscheme->setDay(SchemeDay::THURSDAY, $thursday);
+        $weekscheme->setDay(SchemeDay::FRIDAY, $friday);
+        $weekscheme->setDay(SchemeDay::SATURDAY, $saturday);
+        $weekscheme->setDay(SchemeDay::SUNDAY, $sunday);
+
+        $permanent->setWeekScheme($weekscheme);
+
+        $format = 'sm';
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_Permanent'
+        );
+        $this->formatter->format($permanent, $format);
+    }
+
+    public function testFormatsPermanentWithUnexistingCustomFormat()
+    {
+        $permanent = new CultureFeed_Cdb_Data_Calendar_Permanent();
+
+        $weekscheme = new \CultureFeed_Cdb_Data_Calendar_Weekscheme();
+
+        $monday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::MONDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot1 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $monday->addOpeningTime($ot1);
+
+        $tuesday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::TUESDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot2 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $tuesday->addOpeningTime($ot2);
+
+        $wednesday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::WEDNESDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot3 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $wednesday->addOpeningTime($ot3);
+
+        $thursday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::THURSDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot4 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $thursday->addOpeningTime($ot4);
+
+        $friday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::FRIDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot5 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $friday->addOpeningTime($ot5);
+
+        $saturday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::SATURDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot6 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '19:00:00');
+        $saturday->addOpeningTime($ot6);
+
+        $sunday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::SUNDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot7 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '19:00:00');
+        $sunday->addOpeningTime($ot6);
+
+        $weekscheme->setDay(SchemeDay::MONDAY, $monday);
+        $weekscheme->setDay(SchemeDay::TUESDAY, $tuesday);
+        $weekscheme->setDay(SchemeDay::WEDNESDAY, $wednesday);
+        //$weekscheme->setDay(SchemeDay::THURSDAY, $thursday);
+        $weekscheme->setDay(SchemeDay::FRIDAY, $friday);
+        $weekscheme->setDay(SchemeDay::SATURDAY, $saturday);
+        $weekscheme->setDay(SchemeDay::SUNDAY, $sunday);
+
+        $permanent->setWeekScheme($weekscheme);
+
+        $format = '1337';
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_Permanent'
+        );
+        $this->formatter->format($permanent, $format);
+    }
+}

--- a/tests/CalendarHTMLFormatterTest.php
+++ b/tests/CalendarHTMLFormatterTest.php
@@ -7,6 +7,7 @@
  */
 namespace CultuurNet\CalendarSummary;
 
+use CultureFeed_Cdb_Data_Calendar_Period;
 use CultureFeed_Cdb_Data_Calendar_Permanent;
 use CultureFeed_Cdb_Data_Calendar_Timestamp;
 use CultureFeed_Cdb_Data_Calendar_TimestampList;
@@ -81,18 +82,16 @@ class CalendarHTMLFormatterTest extends \PHPUnit_Framework_TestCase
     public function testFormatsATimestampWithSmallFormat()
     {
         $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
-        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
-        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
-        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
-        $timestamp_list->add($timestamp1);
-        $timestamp_list->add($timestamp2);
-        $timestamp_list->add($timestamp3);
+        $timestamp = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp);
 
-        $this->setExpectedException(
-            '\CultuurNet\CalendarSummary\FormatterException',
-            'sm format not supported for multiple timestamps.'
+        $output = '<span class="cf-date">20</span>';
+        $output .= '<span class="cf-month">sep</span>';
+
+        $this->assertEquals(
+            $output,
+            $this->formatter->format($timestamp_list, 'sm')
         );
-        $this->formatter->format($timestamp_list, 'sm');
     }
 
     public function testFormatsPermanentWithUnexistingSmallFormat()
@@ -223,5 +222,39 @@ class CalendarHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_Permanent'
         );
         $this->formatter->format($permanent, $format);
+    }
+
+    public function testFormatsAPeriodMedium()
+    {
+        $period = new CultureFeed_Cdb_Data_Calendar_Period(
+            '2015-03-20',
+            '2015-03-27'
+        );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
+
+        $this->assertEquals(
+            '<span class="cf-from cf-meta">Van</span> <span class="cf-date">20 maart 2015</span>'
+            . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">27 maart 2015</span>',
+            $this->formatter->format($periodList, 'md')
+        );
+    }
+
+    public function testFormatsAPeriodWithUnexistingCustomFormat()
+    {
+        $period = new CultureFeed_Cdb_Data_Calendar_Period(
+            '2015-03-20',
+            '2015-03-27'
+        );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
+
+        $format = 'cnet';
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_PeriodList'
+        );
+        $this->formatter->format($periodList, $format);
     }
 }

--- a/tests/CalendarHTMLFormatterTest.php
+++ b/tests/CalendarHTMLFormatterTest.php
@@ -7,10 +7,11 @@
  */
 namespace CultuurNet\CalendarSummary;
 
-use CultureFeed_Cdb_Data_Calendar_Period;
-use CultureFeed_Cdb_Data_Calendar_Permanent;
-use CultureFeed_Cdb_Data_Calendar_Timestamp;
-use CultureFeed_Cdb_Data_Calendar_TimestampList;
+use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
+use \CultureFeed_Cdb_Data_Calendar_Permanent;
+use \CultureFeed_Cdb_Data_Calendar_Timestamp;
+use \CultureFeed_Cdb_Data_Calendar_TimestampList;
 use \CultureFeed_Cdb_Data_Calendar_SchemeDay as SchemeDay;
 
 class CalendarHTMLFormatterTest extends \PHPUnit_Framework_TestCase
@@ -230,7 +231,7 @@ class CalendarHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -246,7 +247,7 @@ class CalendarHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $format = 'cnet';

--- a/tests/CalendarPlainTextFormatterTest.php
+++ b/tests/CalendarPlainTextFormatterTest.php
@@ -7,6 +7,7 @@
  */
 namespace CultuurNet\CalendarSummary;
 
+use CultureFeed_Cdb_Data_Calendar_Period;
 use CultureFeed_Cdb_Data_Calendar_Permanent;
 use CultureFeed_Cdb_Data_Calendar_Timestamp;
 use CultureFeed_Cdb_Data_Calendar_TimestampList;
@@ -223,5 +224,38 @@ class CalendarPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_Permanent'
         );
         $this->formatter->format($permanent, $format);
+    }
+
+    public function testFormatsAPeriodMedium()
+    {
+        $period = new CultureFeed_Cdb_Data_Calendar_Period(
+            '2015-03-20',
+            '2015-03-27'
+        );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
+
+        $this->assertEquals(
+            'Van 20 maart 2015 tot 27 maart 2015',
+            $this->formatter->format($periodList, 'md')
+        );
+    }
+
+    public function testFormatsAPeriodWithUnexistingCustomFormat()
+    {
+        $period = new CultureFeed_Cdb_Data_Calendar_Period(
+            '2015-03-20',
+            '2015-03-27'
+        );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
+
+        $format = 'cnet';
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_PeriodList'
+        );
+        $this->formatter->format($periodList, $format);
     }
 }

--- a/tests/CalendarPlainTextFormatterTest.php
+++ b/tests/CalendarPlainTextFormatterTest.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: nicolas
+ * Date: 03/04/15
+ * Time: 14:08
+ */
+namespace CultuurNet\CalendarSummary;
+
+use CultureFeed_Cdb_Data_Calendar_Permanent;
+use CultureFeed_Cdb_Data_Calendar_Timestamp;
+use CultureFeed_Cdb_Data_Calendar_TimestampList;
+use \CultureFeed_Cdb_Data_Calendar_SchemeDay as SchemeDay;
+
+class CalendarPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CalendarPlainTextFormatter
+     */
+    protected $formatter;
+
+
+    public function setUp()
+    {
+        $this->formatter = new CalendarPlainTextFormatter();
+    }
+
+    public function testFormatsMultipleTimestampsWithUnexistingSmallFormat()
+    {
+        $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
+        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp1);
+        $timestamp_list->add($timestamp2);
+        $timestamp_list->add($timestamp3);
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            'sm format not supported for multiple timestamps.'
+        );
+        $this->formatter->format($timestamp_list, 'sm');
+    }
+
+    public function testFormatsMultipleTimestampsWithUnexistingExtraSmallFormat()
+    {
+        $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
+        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp1);
+        $timestamp_list->add($timestamp2);
+        $timestamp_list->add($timestamp3);
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            'xs format not supported for multiple timestamps.'
+        );
+        $this->formatter->format($timestamp_list, 'xs');
+    }
+
+    public function testFormatsMultipleTimestampsWithUnexistingCustomFormat()
+    {
+        $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
+        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp1);
+        $timestamp_list->add($timestamp2);
+        $timestamp_list->add($timestamp3);
+
+        $format = 'cnet';
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_TimestampList'
+        );
+        $this->formatter->format($timestamp_list, $format);
+    }
+
+    public function testFormatsATimestampWithSmallFormat()
+    {
+        $timestamp_list = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+        $timestamp1 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-20', '09:00:00', '12:30:00');
+        $timestamp2 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-21', '09:00:00', '12:30:00');
+        $timestamp3 = new CultureFeed_Cdb_Data_Calendar_Timestamp('2015-09-22', '09:00:00', '12:30:00');
+        $timestamp_list->add($timestamp1);
+        $timestamp_list->add($timestamp2);
+        $timestamp_list->add($timestamp3);
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            'sm format not supported for multiple timestamps.'
+        );
+        $this->formatter->format($timestamp_list, 'sm');
+    }
+
+    public function testFormatsPermanentWithUnexistingSmallFormat()
+    {
+        $permanent = new CultureFeed_Cdb_Data_Calendar_Permanent();
+
+        $weekscheme = new \CultureFeed_Cdb_Data_Calendar_Weekscheme();
+
+        $monday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::MONDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot1 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $monday->addOpeningTime($ot1);
+
+        $tuesday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::TUESDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot2 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $tuesday->addOpeningTime($ot2);
+
+        $wednesday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::WEDNESDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot3 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $wednesday->addOpeningTime($ot3);
+
+        $thursday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::THURSDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot4 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $thursday->addOpeningTime($ot4);
+
+        $friday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::FRIDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot5 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $friday->addOpeningTime($ot5);
+
+        $saturday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::SATURDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot6 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '19:00:00');
+        $saturday->addOpeningTime($ot6);
+
+        $sunday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::SUNDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot7 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '19:00:00');
+        $sunday->addOpeningTime($ot6);
+
+        $weekscheme->setDay(SchemeDay::MONDAY, $monday);
+        $weekscheme->setDay(SchemeDay::TUESDAY, $tuesday);
+        $weekscheme->setDay(SchemeDay::WEDNESDAY, $wednesday);
+        //$weekscheme->setDay(SchemeDay::THURSDAY, $thursday);
+        $weekscheme->setDay(SchemeDay::FRIDAY, $friday);
+        $weekscheme->setDay(SchemeDay::SATURDAY, $saturday);
+        $weekscheme->setDay(SchemeDay::SUNDAY, $sunday);
+
+        $permanent->setWeekScheme($weekscheme);
+
+        $format = 'sm';
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_Permanent'
+        );
+        $this->formatter->format($permanent, $format);
+    }
+
+    public function testFormatsPermanentWithUnexistingCustomFormat()
+    {
+        $permanent = new CultureFeed_Cdb_Data_Calendar_Permanent();
+
+        $weekscheme = new \CultureFeed_Cdb_Data_Calendar_Weekscheme();
+
+        $monday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::MONDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot1 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $monday->addOpeningTime($ot1);
+
+        $tuesday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::TUESDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot2 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $tuesday->addOpeningTime($ot2);
+
+        $wednesday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::WEDNESDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot3 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $wednesday->addOpeningTime($ot3);
+
+        $thursday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::THURSDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot4 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $thursday->addOpeningTime($ot4);
+
+        $friday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::FRIDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
+        $ot5 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '13:00:00');
+        $friday->addOpeningTime($ot5);
+
+        $saturday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::SATURDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot6 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '19:00:00');
+        $saturday->addOpeningTime($ot6);
+
+        $sunday = new \CultureFeed_Cdb_Data_Calendar_SchemeDay(
+            SchemeDay::SUNDAY,
+            SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN
+        );
+        $ot7 = new \CultureFeed_Cdb_Data_Calendar_OpeningTime('09:00:00', '19:00:00');
+        $sunday->addOpeningTime($ot6);
+
+        $weekscheme->setDay(SchemeDay::MONDAY, $monday);
+        $weekscheme->setDay(SchemeDay::TUESDAY, $tuesday);
+        $weekscheme->setDay(SchemeDay::WEDNESDAY, $wednesday);
+        //$weekscheme->setDay(SchemeDay::THURSDAY, $thursday);
+        $weekscheme->setDay(SchemeDay::FRIDAY, $friday);
+        $weekscheme->setDay(SchemeDay::SATURDAY, $saturday);
+        $weekscheme->setDay(SchemeDay::SUNDAY, $sunday);
+
+        $permanent->setWeekScheme($weekscheme);
+
+        $format = '1337';
+
+        $this->setExpectedException(
+            '\CultuurNet\CalendarSummary\FormatterException',
+            $format . ' format not supported for CultureFeed_Cdb_Data_Calendar_Permanent'
+        );
+        $this->formatter->format($permanent, $format);
+    }
+}

--- a/tests/CalendarPlainTextFormatterTest.php
+++ b/tests/CalendarPlainTextFormatterTest.php
@@ -7,10 +7,11 @@
  */
 namespace CultuurNet\CalendarSummary;
 
-use CultureFeed_Cdb_Data_Calendar_Period;
-use CultureFeed_Cdb_Data_Calendar_Permanent;
-use CultureFeed_Cdb_Data_Calendar_Timestamp;
-use CultureFeed_Cdb_Data_Calendar_TimestampList;
+use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
+use \CultureFeed_Cdb_Data_Calendar_Permanent;
+use \CultureFeed_Cdb_Data_Calendar_Timestamp;
+use \CultureFeed_Cdb_Data_Calendar_TimestampList;
 use \CultureFeed_Cdb_Data_Calendar_SchemeDay as SchemeDay;
 
 class CalendarPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
@@ -232,7 +233,7 @@ class CalendarPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -247,7 +248,7 @@ class CalendarPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $format = 'cnet';

--- a/tests/Period/ExtraSmallPeriodHTMLFormatterTest.php
+++ b/tests/Period/ExtraSmallPeriodHTMLFormatterTest.php
@@ -6,6 +6,7 @@
 namespace CultuurNet\CalendarSummary\Period;
 
 use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
 
 class ExtraSmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,7 +26,7 @@ class ExtraSmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -40,7 +41,7 @@ class ExtraSmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-01',
             '2015-03-05'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(

--- a/tests/Period/ExtraSmallPeriodHTMLFormatterTest.php
+++ b/tests/Period/ExtraSmallPeriodHTMLFormatterTest.php
@@ -25,10 +25,12 @@ class ExtraSmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '<span class="cf-date">20</span>/<span class="cf-month">03</span>',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 
@@ -38,10 +40,12 @@ class ExtraSmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-01',
             '2015-03-05'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '<span class="cf-date">1</span>/<span class="cf-month">03</span>',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 }

--- a/tests/Period/ExtraSmallPeriodPlainTextFormatterTest.php
+++ b/tests/Period/ExtraSmallPeriodPlainTextFormatterTest.php
@@ -25,10 +25,12 @@ class ExtraSmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '20/03',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 
@@ -38,10 +40,12 @@ class ExtraSmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-01',
             '2015-03-05'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '1/03',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 }

--- a/tests/Period/ExtraSmallPeriodPlainTextFormatterTest.php
+++ b/tests/Period/ExtraSmallPeriodPlainTextFormatterTest.php
@@ -6,6 +6,7 @@
 namespace CultuurNet\CalendarSummary\Period;
 
 use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
 
 class ExtraSmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,7 +26,7 @@ class ExtraSmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -40,7 +41,7 @@ class ExtraSmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-01',
             '2015-03-05'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(

--- a/tests/Period/LargePeriodHTMLFormatterTest.php
+++ b/tests/Period/LargePeriodHTMLFormatterTest.php
@@ -29,6 +29,7 @@ class LargePeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
+
         $weekscheme=new \CultureFeed_Cdb_Data_Calendar_Weekscheme();
 
         $monday=new \CultureFeed_Cdb_Data_Calendar_SchemeDay(SchemeDay::MONDAY, SchemeDay::SCHEMEDAY_OPEN_TYPE_OPEN);
@@ -74,6 +75,9 @@ class LargePeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
 
         $period->setWeekScheme($weekscheme);
 
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
+
         $this->assertEquals(
             '<p><time itemprop="startDate" datetime="2015-03-20"><span class="cf-date">20 maart 2015</span></time>'
             . '<span class="cf-to cf-meta">tot</span><time itemprop="endDate" datetime="2015-03-27">'
@@ -94,7 +98,7 @@ class LargePeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             . '<span itemprop="closes" content="13:00" class="cf-to cf-meta">tot</span>13:00'
             . '<span itemprop="opens" content="17:00" class="cf-from cf-meta">van</span>17:00'
             . '<span itemprop="closes" content="20:00" class="cf-to cf-meta">tot</span>20:00</li></ul>',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 }

--- a/tests/Period/LargePeriodHTMLFormatterTest.php
+++ b/tests/Period/LargePeriodHTMLFormatterTest.php
@@ -9,6 +9,7 @@
 namespace CultuurNet\CalendarSummary\Period;
 
 use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
 use \CultureFeed_Cdb_Data_Calendar_SchemeDay as SchemeDay;
 
 class LargePeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
@@ -75,7 +76,7 @@ class LargePeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
 
         $period->setWeekScheme($weekscheme);
 
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(

--- a/tests/Period/LargePeriodPlainTextFormatterTest.php
+++ b/tests/Period/LargePeriodPlainTextFormatterTest.php
@@ -9,6 +9,7 @@
 namespace CultuurNet\CalendarSummary\Period;
 
 use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
 use \CultureFeed_Cdb_Data_Calendar_SchemeDay as SchemeDay;
 
 class LargePeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
@@ -74,7 +75,7 @@ class LargePeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
 
         $period->setWeekScheme($weekscheme);
 
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(

--- a/tests/Period/LargePeriodPlainTextFormatterTest.php
+++ b/tests/Period/LargePeriodPlainTextFormatterTest.php
@@ -74,12 +74,15 @@ class LargePeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
 
         $period->setWeekScheme($weekscheme);
 
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
+
         $this->assertEquals(
             'Van 20 maart 2015 tot 27 maart 2015\nMa Van 9:00 tot 13:00\nVan 17:00 tot 20:00\n'
             . 'Di Van 9:00 tot 13:00\nVan 17:00 tot 20:00\nWo Van 9:00 tot 17:00\nDo  gesloten\n'
             . 'Vr Van 9:00 tot 13:00\nVan 17:00 tot 20:00\nZa Van 9:00 tot 13:00\n'
             . 'Van 17:00 tot 20:00\nZo  gesloten\n',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 }

--- a/tests/Period/MediumPeriodHTMLFormatterTest.php
+++ b/tests/Period/MediumPeriodHTMLFormatterTest.php
@@ -9,6 +9,7 @@
 namespace CultuurNet\CalendarSummary\Period;
 
 use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
 
 class MediumPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +29,7 @@ class MediumPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -44,7 +45,7 @@ class MediumPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-01',
             '2015-03-05'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(

--- a/tests/Period/MediumPeriodHTMLFormatterTest.php
+++ b/tests/Period/MediumPeriodHTMLFormatterTest.php
@@ -28,11 +28,13 @@ class MediumPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '<span class="cf-from cf-meta">Van</span> <span class="cf-date">20 maart 2015</span>'
             . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">27 maart 2015</span>',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 
@@ -42,11 +44,13 @@ class MediumPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-01',
             '2015-03-05'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '<span class="cf-from cf-meta">Van</span> <span class="cf-date">1 maart 2015</span>'
             . '<span class="cf-to cf-meta">tot</span> <span class="cf-date">5 maart 2015</span>',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 }

--- a/tests/Period/MediumPeriodPlainTextFormatterTest.php
+++ b/tests/Period/MediumPeriodPlainTextFormatterTest.php
@@ -9,6 +9,7 @@
 namespace CultuurNet\CalendarSummary\Period;
 
 use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
 
 class MediumPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +29,7 @@ class MediumPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -43,7 +44,7 @@ class MediumPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-01',
             '2015-03-05'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(

--- a/tests/Period/MediumPeriodPlainTextFormatterTest.php
+++ b/tests/Period/MediumPeriodPlainTextFormatterTest.php
@@ -28,10 +28,12 @@ class MediumPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-20',
             '2015-03-27'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             'Van 20 maart 2015 tot 27 maart 2015',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 
@@ -41,10 +43,12 @@ class MediumPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-01',
             '2015-03-05'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             'Van 1 maart 2015 tot 5 maart 2015',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 }

--- a/tests/Period/SmallPeriodHTMLFormatterTest.php
+++ b/tests/Period/SmallPeriodHTMLFormatterTest.php
@@ -9,6 +9,7 @@
 namespace CultuurNet\CalendarSummary\Period;
 
 use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
 
 class SmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +29,7 @@ class SmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2020-03-20',
             '2025-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -43,7 +44,7 @@ class SmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2020-03-01',
             '2025-03-05'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -58,7 +59,7 @@ class SmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-19',
             '2020-03-25'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(

--- a/tests/Period/SmallPeriodHTMLFormatterTest.php
+++ b/tests/Period/SmallPeriodHTMLFormatterTest.php
@@ -28,10 +28,12 @@ class SmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2020-03-20',
             '2025-03-27'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '<span class="from meta">Vanaf</span> <span class="cf-date">20</span> <span class="cf-month">mrt</span>',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 
@@ -41,10 +43,12 @@ class SmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2020-03-01',
             '2025-03-05'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '<span class="from meta">Vanaf</span> <span class="cf-date">1</span> <span class="cf-month">mrt</span>',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 
@@ -54,10 +58,12 @@ class SmallPeriodHTMLFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-19',
             '2020-03-25'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             '<span class="to meta">Tot</span> <span class="cf-date">25</span> <span class="cf-month">mrt</span>',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 }

--- a/tests/Period/SmallPeriodPlainTextFormatterTest.php
+++ b/tests/Period/SmallPeriodPlainTextFormatterTest.php
@@ -9,6 +9,7 @@
 namespace CultuurNet\CalendarSummary\Period;
 
 use \CultureFeed_Cdb_Data_Calendar_Period;
+use \CultureFeed_Cdb_Data_Calendar_PeriodList;
 
 class SmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +29,7 @@ class SmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2020-03-20',
             '2025-03-27'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -43,7 +44,7 @@ class SmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2020-03-01',
             '2025-03-05'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(
@@ -58,7 +59,7 @@ class SmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-19',
             '2020-03-25'
         );
-        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList = new CultureFeed_Cdb_Data_Calendar_PeriodList();
         $periodList->add($period);
 
         $this->assertEquals(

--- a/tests/Period/SmallPeriodPlainTextFormatterTest.php
+++ b/tests/Period/SmallPeriodPlainTextFormatterTest.php
@@ -28,10 +28,12 @@ class SmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2020-03-20',
             '2025-03-27'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             'Vanaf 20 mrt',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 
@@ -41,10 +43,12 @@ class SmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2020-03-01',
             '2025-03-05'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             'Vanaf 1 mrt',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 
@@ -54,10 +58,12 @@ class SmallPeriodPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
             '2015-03-19',
             '2020-03-25'
         );
+        $periodList = new \CultureFeed_Cdb_Data_Calendar_PeriodList();
+        $periodList->add($period);
 
         $this->assertEquals(
             'Tot 25 mrt',
-            $this->formatter->format($period)
+            $this->formatter->format($periodList)
         );
     }
 }

--- a/tests/Timestamps/SmallTimestampsHTMLFormatterTest.php
+++ b/tests/Timestamps/SmallTimestampsHTMLFormatterTest.php
@@ -66,7 +66,7 @@ class SmallTimestampsHTMLFormatterTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(
             '\CultuurNet\CalendarSummary\FormatterException',
-            's format not supported for multiple timestamps.'
+            'sm format not supported for multiple timestamps.'
         );
         $this->formatter->format($timestamp_list);
     }

--- a/tests/Timestamps/SmallTimestampsPlainTextFormatterTest.php
+++ b/tests/Timestamps/SmallTimestampsPlainTextFormatterTest.php
@@ -60,7 +60,7 @@ class SmallTimestampsPlainTextFormatterTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(
             '\CultuurNet\CalendarSummary\FormatterException',
-            's format not supported for multiple timestamps.'
+            'sm format not supported for multiple timestamps.'
         );
         $this->formatter->format($timestamp_list);
     }


### PR DESCRIPTION
The CultureFeed_Cdb_Data_Calendar_Period class seemed not to be extending CultureFeed_Cdb_Data_Calendar. This was a problem on the general HTML and PlainText formatters. As they expect a CultureFeed_Cdb_Data_Calendar object. 
Apparently there was a CultureFeed_Cdb_Data_Calendar_PeriodList class that extended the CultureFeed_Cdb_Data_Calendar class. Changed the code and test accordingly.
