### PR TITLE
Explicitly define the intl PHP extension requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
       "dev-develop": "1.1.x-dev"
     }
   },
+  "require": {
+    "ext-intl": "*"
+  },
   "require-dev": {
     "phpunit/phpunit": "~4.5",
     "squizlabs/php_codesniffer": "~2.2",


### PR DESCRIPTION
The calendar-summary formatters rely on the IntlDateFormatter class which is part of the intl PHP extension. The intl extension is not available out of the box on all platforms, depending on how PHP was compiled. For example, on the stock install of OS X Mavericks it's entirely missing. Therefore it's good to explicitly mention the requirement in composer.json, so when installing the package people are notified if the required intl is missing.
