### PR TITLE
Use token for slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ notifications:
    recipients:
    - nicolas.leroy@gmail.com
 notifications:
-  slack: cnet:UzmZZjVck1RNHTyrTSe6NTd9
+  slack: '<account>:<token>'


### PR DESCRIPTION
Note: We highly recommend you [encrypt](https://docs.travis-ci.com/user/encryption-keys/) this value if your .travis.yml is stored in a public repository:

```
travis encrypt "<account>:<token>" --add notifications.slack.rooms
```

See https://docs.travis-ci.com/user/notifications/#configuring-slack-notifications